### PR TITLE
Enable markdown syntax for roxygen2 comments

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,3 +33,4 @@ Imports:
     magrittr
 RoxygenNote: 7.1.0
 VignetteBuilder: knitr
+Roxygen: list(markdown = TRUE)

--- a/R/cdc.R
+++ b/R/cdc.R
@@ -7,7 +7,7 @@ BIN_PREDICTION_CLASS <- "bin"  # "" bin ""
 #'
 #' @return cdc_csv_file's data as Zoltar's native `list` format, but only the "predictions" item, and not "meta"
 #' @param season_start_year An integer specifying the "season" that cdc_csv_file is in. Used to convert EWs to
-#'   YYYY_MM_DD_DATE_FORMAT. zoltr uses week 30 as the season breakpoint, e.g. the "2016/2017 season" starts with
+#'   YYYY_MM_DD_DATE_FORMAT. \pkg{zoltr} uses week 30 as the season breakpoint, e.g. the "2016/2017 season" starts with
 #    EW30-2016 (EWs 30 through 52/53) and ends with EW29-2017 (EWs 01 through 29).
 #' @param cdc_csv_file A CDC CSV file
 #' @export
@@ -41,10 +41,10 @@ forecast_data_from_cdc_csv_file <- function(season_start_year, cdc_csv_file) {
 #
 
 
-#' `forecast_data_from_cdc_csv_file()`helper
+#' [forecast_data_from_cdc_csv_file()] helper
 #'
-#' @return same as `forecast_data_from_cdc_csv_file()`
-#' @param season_start_year as passed to `forecast_data_from_cdc_csv_file()`
+#' @return same as [forecast_data_from_cdc_csv_file()}
+#' @param season_start_year as passed to [forecast_data_from_cdc_csv_file()]
 #' @param cdc_data_frame ""
 #' @importFrom rlang .data
 forecast_data_from_cdc_data_frame <- function(season_start_year, cdc_data_frame) {  # testable internal function that does the work

--- a/R/cdc.R
+++ b/R/cdc.R
@@ -43,7 +43,7 @@ forecast_data_from_cdc_csv_file <- function(season_start_year, cdc_csv_file) {
 
 #' [forecast_data_from_cdc_csv_file()] helper
 #'
-#' @return same as [forecast_data_from_cdc_csv_file()}
+#' @return same as [forecast_data_from_cdc_csv_file()]
 #' @param season_start_year as passed to [forecast_data_from_cdc_csv_file()]
 #' @param cdc_data_frame ""
 #' @importFrom rlang .data

--- a/R/connection.R
+++ b/R/connection.R
@@ -26,7 +26,7 @@ add_auth_headers <- function(zoltar_connection) {
 #' Get JSON for a resource (URL). Authenticates if necessary
 #'
 #' @return A `list` that contiains JSON information for the passed URL
-#' @param zoltar_connection A `ZoltarConnection` object as returned by \code{\link{new_connection}}
+#' @param zoltar_connection A `ZoltarConnection` object as returned by [new_connection()]
 #' @param url A string of the resource's URL
 #' @param col_types Same as readr::read_csv takes
 get_resource <- function(zoltar_connection, url, col_types = NULL) {
@@ -62,14 +62,14 @@ delete_resource <- function(zoltar_connection, url) {
 #' Get a connection to a Zoltar host
 #'
 #' Returns a new connection object, which is the starting point for working with the Zoltar API. Once you have the
-#' connection you can call \code{\link{zoltar_authenticate}} on it, and then call \code{\link{projects}} to get a list
+#' connection you can call [zoltar_authenticate()] on it, and then call [projects()] to get a list
 #' of Project objects to start working with.
 #'
 #' A note on URLs: We require a trailing slash ('/') on all URLs. The only exception is the host arg passed to this
 #' function. This convention matches Django REST framework one, which is what Zoltar is written in.
 #'
 #' @return A `ZoltarConnection` object
-#' @param host The Zoltar site to connect to. Does *not* include a trailing slash ('/'). Defaults to \url{https://zoltardata.com}
+#' @param host The Zoltar site to connect to. Does *not* include a trailing slash ('/'). Defaults to <https://zoltardata.com>
 #' @export
 #' @examples \dontrun{
 #'   conn <- new_connection()
@@ -102,7 +102,7 @@ print.ZoltarConnection <-
 #' to start working with.
 #'
 #' @return None
-#' @param zoltar_connection A `ZoltarConnection` object as returned by \code{\link{new_connection}}.
+#' @param zoltar_connection A `ZoltarConnection` object as returned by [new_connection()].
 #' @param username Username for the account to use on the connection's host
 #' @param password Password ""
 #' @export
@@ -135,7 +135,7 @@ re_authenticate_if_necessary <- function(zoltar_connection) {
 #' Get information about all projects
 #'
 #' @return A `data.frame` of all projects' contents
-#' @param zoltar_connection A `ZoltarConnection` object as returned by \code{\link{new_connection}}
+#' @param zoltar_connection A `ZoltarConnection` object as returned by [new_connection()]
 #' @export
 #' @examples \dontrun{
 #'   the_projects <- projects(conn)

--- a/R/connection.R
+++ b/R/connection.R
@@ -98,7 +98,7 @@ print.ZoltarConnection <-
 #' Log in to a Zoltar host
 #'
 #' Returns a new `ZoltarConnection` object, which is the starting point for working with the Zoltar API.
-#' Once you have the connection you can call zoltar_authenticate() on it, and call projects() to get a list of objects
+#' Once you have the connection you can call [zoltar_authenticate()] on it, and call [projects()] to get a list of objects
 #' to start working with.
 #'
 #' @return None

--- a/R/connection.R
+++ b/R/connection.R
@@ -25,7 +25,7 @@ add_auth_headers <- function(zoltar_connection) {
 
 #' Get JSON for a resource (URL). Authenticates if necessary
 #'
-#' @return A `list` that contiains JSON information for the passed URL
+#' @return A `list` that contains JSON information for the passed URL
 #' @param zoltar_connection A `ZoltarConnection` object as returned by [new_connection()]
 #' @param url A string of the resource's URL
 #' @param col_types Same as readr::read_csv takes

--- a/R/forecast.R
+++ b/R/forecast.R
@@ -5,7 +5,7 @@
 #' Gets a forecast's information
 #'
 #' @return A `list` of forecast information for the passed forecast_url
-#' @param zoltar_connection A `ZoltarConnection` object as returned by \code{\link{new_connection}}
+#' @param zoltar_connection A `ZoltarConnection` object as returned by [new_connection()]
 #' @param forecast_url URL of a forecast in zoltar_connection's forecasts
 #' @export
 #' @examples \dontrun{
@@ -29,7 +29,7 @@ forecast_info <- function(zoltar_connection, forecast_url) {
 #' Deletes the forecast with the passed URL. This is permanent and cannot be undone.
 #'
 #' @return A Job URL for the deletion
-#' @param zoltar_connection A `ZoltarConnection` object as returned by \code{\link{new_connection}}
+#' @param zoltar_connection A `ZoltarConnection` object as returned by [new_connection()]
 #' @param forecast_url URL of a forecast in zoltar_connection's forecasts
 #' @export
 #' @examples \dontrun{
@@ -45,8 +45,8 @@ delete_forecast <- function(zoltar_connection, forecast_url) {
 #' Gets a forecast's data
 #'
 #' @return Forecast data as a `list` in the Zoltar standard format. meta information is ignored. Full documentation at
-#'   \url{https://docs.zoltardata.com/}.
-#' @param zoltar_connection A `ZoltarConnection` object as returned by \code{\link{new_connection}}
+#'   <https://docs.zoltardata.com/>.
+#' @param zoltar_connection A `ZoltarConnection` object as returned by [new_connection()]
 #' @param forecast_url URL of a forecast in zoltar_connection's forecasts
 #' @export
 #' @examples \dontrun{

--- a/R/job.R
+++ b/R/job.R
@@ -64,10 +64,10 @@ job_info_forecast_url <- function(zoltar_connection, the_job_info) {
 #' Gets a job's file's data
 #'
 #' Downloads the data for jobs that have an associated file, such as a query's results. Called on Jobs
-#' that are the results of a project forecast or truth queries via `submit_query()`. NB: It is a 404 Not Found
+#' that are the results of a project forecast or truth queries via [submit_query()]. NB: It is a 404 Not Found
 #' error if this is called on a Job that has no underlying S3 data file, which can happen b/c: 1) 24 hours has
 #' passed (the expiration time) or 2) the Job is not complete and therefore has not saved the data file. For
-#' the latter you may use `busy_poll_job()` to ensure the job is done.
+#' the latter you may use [busy_poll_job()] to ensure the job is done.
 #'
 #' @return A `data.frame` of Job's data. The columns depend on query_type - see
 #'   <https://docs.zoltardata.com/fileformats/#truth-data-format-csv> and

--- a/R/job.R
+++ b/R/job.R
@@ -25,7 +25,7 @@ status_as_str <- function(status_int) {
 #'
 #' @return A `list` of job information for the passed job_url. it has these names:
 #'   id, url, status, user, created_at, updated_at, failure_message, input_json, output_json
-#' @param zoltar_connection A `ZoltarConnection` object as returned by \code{\link{new_connection}}
+#' @param zoltar_connection A `ZoltarConnection` object as returned by [new_connection()]
 #' @param job_url URL of a valid job in zoltar_connection
 #' @export
 #' @examples \dontrun{
@@ -46,8 +46,8 @@ job_info <- function(zoltar_connection, job_url) {
 #' from job_info.
 #'
 #' @return A URL of the new forecast
-#' @param zoltar_connection A `ZoltarConnection` object as returned by \code{\link{new_connection}}
-#' @param the_job_info a `list` object as returned by \code{\link{job_info}}
+#' @param zoltar_connection A `ZoltarConnection` object as returned by [new_connection()]
+#' @param the_job_info a `list` object as returned by [job_info()]
 #' @export
 #' @examples \dontrun{
 #'   new_forecast_url <- job_info_forecast_url(conn, "http://example.com/api/job/2/")
@@ -70,9 +70,9 @@ job_info_forecast_url <- function(zoltar_connection, the_job_info) {
 #' the latter you may use `busy_poll_job()` to ensure the job is done.
 #'
 #' @return A `data.frame` of Job's data. The columns depend on query_type - see
-#'   \url{https://docs.zoltardata.com/fileformats/#truth-data-format-csv} and
-#'   \url{https://docs.zoltardata.com/fileformats/#forecast-data-format-csv}.
-#' @param zoltar_connection A `ZoltarConnection` object as returned by \code{\link{new_connection}}
+#'   <https://docs.zoltardata.com/fileformats/#truth-data-format-csv> and
+#'   <https://docs.zoltardata.com/fileformats/#forecast-data-format-csv>.
+#' @param zoltar_connection A `ZoltarConnection` object as returned by [new_connection()]
 #' @param job_url URL of a valid job in zoltar_connection that has a data file associated with it
 #' @param query_type A character indicating the type of query to run. Must be one of: "forecasts" or "truth".
 #' @export
@@ -109,7 +109,7 @@ job_data <- function(zoltar_connection, job_url, query_type) {
 #'
 #' A convenience function that polls the passed Job's status waiting for either FAILED, TIMEOUT, or SUCCESS.
 #'
-#' @param zoltar_connection A `ZoltarConnection` object as returned by \code{\link{new_connection}}
+#' @param zoltar_connection A `ZoltarConnection` object as returned by [new_connection()]
 #' @param job_url URL of a valid job in zoltar_connection
 #' @param verbose if TRUE, print messages on job status poll
 #' @export

--- a/R/model.R
+++ b/R/model.R
@@ -62,7 +62,7 @@ create_model <- function(zoltar_connection, project_url, model_config) {
 #' Edits the model in the passed project using the passed list. Fails if a model with the passed name already exists.
 #'
 #' @param zoltar_connection A `ZoltarConnection` object as returned by [new_connection()]
-#' @param model_url url of a project in zoltar_connection's projects. this is the project the new model will be editd
+#' @param model_url url of a project in zoltar_connection's projects. this is the project the new model will be edited
 #'   in
 #' @param model_config A `list` containing a Zoltar model configuration. An example: example-model-config.json .
 #'   Full documentation at <https://docs.zoltardata.com/>.

--- a/R/model.R
+++ b/R/model.R
@@ -8,7 +8,7 @@ YYYY_MM_DD_DATE_FORMAT <- "%Y-%m-%d"  # e.g., '2017-01-17'
 #' Get information about a model
 #'
 #' @return A `list` of model information for the passed model_url
-#' @param zoltar_connection A `ZoltarConnection` object as returned by \code{\link{new_connection}}
+#' @param zoltar_connection A `ZoltarConnection` object as returned by [new_connection()]
 #' @param model_url URL of a model in zoltar_connection's models
 #' @export
 #' @examples \dontrun{
@@ -27,11 +27,11 @@ model_info <- function(zoltar_connection, model_url) {
 #' Creates the model in the passed project using the passed list. Fails if a model with the passed name already exists.
 #'
 #' @return model_url of the newly-created model
-#' @param zoltar_connection A `ZoltarConnection` object as returned by \code{\link{new_connection}}
+#' @param zoltar_connection A `ZoltarConnection` object as returned by [new_connection()]
 #' @param project_url url of a project in zoltar_connection's projects. this is the project the new model will be created
 #'   in
 #' @param model_config A `list` containing a Zoltar model configuration. An example: example-model-config.json .
-#'   Full documentation at \url{https://docs.zoltardata.com/}.
+#'   Full documentation at <https://docs.zoltardata.com/>.
 #' @export
 #' @examples \dontrun{
 #'   new_model_url <- create_model(conn, "https://www.zoltardata.com/api/project/9/",
@@ -61,11 +61,11 @@ create_model <- function(zoltar_connection, project_url, model_config) {
 #'
 #' Edits the model in the passed project using the passed list. Fails if a model with the passed name already exists.
 #'
-#' @param zoltar_connection A `ZoltarConnection` object as returned by \code{\link{new_connection}}
+#' @param zoltar_connection A `ZoltarConnection` object as returned by [new_connection()]
 #' @param model_url url of a project in zoltar_connection's projects. this is the project the new model will be editd
 #'   in
 #' @param model_config A `list` containing a Zoltar model configuration. An example: example-model-config.json .
-#'   Full documentation at \url{https://docs.zoltardata.com/}.
+#'   Full documentation at <https://docs.zoltardata.com/>.
 #' @export
 #' @examples \dontrun{
 #'   edit_model(conn, "https://www.zoltardata.com/api/model/2/",
@@ -93,7 +93,7 @@ edit_model <- function(zoltar_connection, model_url, model_config) {
 #' Deletes the model with the passed ID. This is permanent and cannot be undone.
 #'
 #' @return None
-#' @param zoltar_connection A `ZoltarConnection` object as returned by \code{\link{new_connection}}
+#' @param zoltar_connection A `ZoltarConnection` object as returned by [new_connection()]
 #' @param model_url URL of a model in zoltar_connection's models
 #' @export
 #' @examples \dontrun{
@@ -107,7 +107,7 @@ delete_model <- function(zoltar_connection, model_url) {
 #' Get a model's forecasts
 #'
 #' @return A `data.frame` of forecast information for the passed model
-#' @param zoltar_connection A `ZoltarConnection` object as returned by \code{\link{new_connection}}
+#' @param zoltar_connection A `ZoltarConnection` object as returned by [new_connection()]
 #' @param model_url URL of a model in zoltar_connection's models
 #' @export
 #' @examples \dontrun{
@@ -164,7 +164,7 @@ forecasts <- function(zoltar_connection, model_url) {
 #' up, which depends on the number of current uploads in the queue. Zoltar tracks these via `Job` objects.)
 #'
 #' @return A Job URL for the upload
-#' @param zoltar_connection A `ZoltarConnection` object as returned by \code{\link{new_connection}}
+#' @param zoltar_connection A `ZoltarConnection` object as returned by [new_connection()]
 #' @param model_url URL of a model in zoltar_connection's projects
 #' @param timezero_date The date of the project timezero you are uploading for. it is a string in format YYYYMMDD
 #' @param forecast_data Forecast data as a `list` in the Zoltar standard format

--- a/R/project.R
+++ b/R/project.R
@@ -8,9 +8,9 @@
 #'   exists.
 #'
 #' @return project_url of the newly-created project
-#' @param zoltar_connection A `ZoltarConnection` object as returned by \code{\link{new_connection}}
+#' @param zoltar_connection A `ZoltarConnection` object as returned by [new_connection()]
 #' @param project_config A `list` containing a Zoltar project configuration. note that this list validated by the
-#'   server and not here. An example: cdc-project.json Full documentation at \url{https://docs.zoltardata.com/}.
+#'   server and not here. An example: cdc-project.json Full documentation at <https://docs.zoltardata.com/>.
 #' @export
 #' @examples \dontrun{
 #'   new_project_url <- create_project(conn, jsonlite::read_json("cdc-project.json"))
@@ -40,7 +40,7 @@ create_project <- function(zoltar_connection, project_config) {
 #' Deletes the project with the passed URL. This is permanent and cannot be undone.
 #'
 #' @return None
-#' @param zoltar_connection A `ZoltarConnection` object as returned by \code{\link{new_connection}}
+#' @param zoltar_connection A `ZoltarConnection` object as returned by [new_connection()]
 #' @param project_url URL of a project in zoltar_connection's projects
 #' @export
 #' @examples \dontrun{
@@ -54,7 +54,7 @@ delete_project <- function(zoltar_connection, project_url) {
 #' Get a project's models
 #'
 #' @return A `data.frame` of model contents for all models in the passed project
-#' @param zoltar_connection A `ZoltarConnection` object as returned by \code{\link{new_connection}}
+#' @param zoltar_connection A `ZoltarConnection` object as returned by [new_connection()]
 #' @param project_url URL of a project in zoltar_connection's projects
 #' @export
 #' @examples \dontrun{
@@ -100,7 +100,7 @@ models <- function(zoltar_connection, project_url) {
 #' Get a project's zoltar_units
 #'
 #' @return A `data.frame` of unit contents for the passed project
-#' @param zoltar_connection A `ZoltarConnection` object as returned by \code{\link{new_connection}}
+#' @param zoltar_connection A `ZoltarConnection` object as returned by [new_connection()]
 #' @param project_url URL of a project in zoltar_connection's projects
 #' @export
 #' @examples \dontrun{
@@ -124,7 +124,7 @@ zoltar_units <- function(zoltar_connection, project_url) {
 #' Get a project's targets
 #'
 #' @return A `data.frame` of target contents for the passed project
-#' @param zoltar_connection A `ZoltarConnection` object as returned by \code{\link{new_connection}}
+#' @param zoltar_connection A `ZoltarConnection` object as returned by [new_connection()]
 #' @param project_url URL of a project in zoltar_connection's projects
 #' @export
 #' @examples \dontrun{
@@ -170,7 +170,7 @@ data_frame_from_targets_json <- function(targets_json) {
 #' Get a project's timezeros
 #'
 #' @return A `data.frame` of timezero contents for the passed project
-#' @param zoltar_connection A `ZoltarConnection` object as returned by \code{\link{new_connection}}
+#' @param zoltar_connection A `ZoltarConnection` object as returned by [new_connection()]
 #' @param project_url URL of a project in zoltar_connection's projects
 #' @export
 #' @examples \dontrun{
@@ -210,7 +210,7 @@ timezeros <- function(zoltar_connection, project_url) {
 #' @return A `data.frame` of all of the latest forecasts for the passed project. columns: forecast_id, source.
 #'   (Later we may generalize to allow passing specific columns to retrieve, such as 'forecast_model_id',
 #'   'time_zero_id', 'issued_at', 'created_at', 'source', and 'notes'.)
-#' @param zoltar_connection A `ZoltarConnection` object as returned by \code{\link{new_connection}}
+#' @param zoltar_connection A `ZoltarConnection` object as returned by [new_connection()]
 #' @param project_url URL of a project in zoltar_connection's projects
 #' @export
 #' @examples \dontrun{
@@ -231,11 +231,11 @@ latest_forecasts <- function(zoltar_connection, project_url) {
 #' Submits a request for the execution of a query of either forecasts or truth in this Project.
 #'
 #' @return a Job URL for tracking the query and getting its results when it successfully completes
-#' @param zoltar_connection A `ZoltarConnection` object as returned by \code{\link{new_connection}}
+#' @param zoltar_connection A `ZoltarConnection` object as returned by [new_connection()]
 #' @param project_url URL of a project in zoltar_connection's projects
 #' @param query_type A character indicating the type of query to run. Must be one of: "forecasts" or "truth".
 #' @param query A `list` of character `list`s that constrains the queried data. It is the analog of
-#'   the JSON object documented at \url{https://docs.zoltardata.com/}. The keys vary depending on query_type. References
+#'   the JSON object documented at <https://docs.zoltardata.com/>. The keys vary depending on query_type. References
 #'   to models, units, targets, and timezeros are strings that name the objects, and not IDs.
 #' @export
 #' @examples \dontrun{
@@ -281,8 +281,8 @@ json_for_query <- function(query) {
 
 #' A convenience function to construct and execute a Zoltar query for either forecast or truth data.
 #'
-#' @return A `data.frame` of Job's data. Full documentation at \url{https://docs.zoltardata.com/}.
-#' @param zoltar_connection A `ZoltarConnection` object as returned by \code{\link{new_connection}}
+#' @return A `data.frame` of Job's data. Full documentation at <https://docs.zoltardata.com/>.
+#' @param zoltar_connection A `ZoltarConnection` object as returned by [new_connection()]
 #' @param project_url URL of a project in zoltar_connection's projects
 #' @param query_type A character indicating the type of query to run. Must be one of: "forecasts" or "truth".
 #' @param models Character vector of model abbreviations. Used for query_type = "forecasts".
@@ -344,7 +344,7 @@ do_zoltar_query <- function(zoltar_connection, project_url, query_type, models =
 #' Get information about a project
 #'
 #' @return A `list` of project information for the passed project_url
-#' @param zoltar_connection A `ZoltarConnection` object as returned by \code{\link{new_connection}}
+#' @param zoltar_connection A `ZoltarConnection` object as returned by [new_connection()]
 #' @param project_url URL of a project in zoltar_connection's projects
 #' @export
 #' @examples \dontrun{
@@ -358,7 +358,7 @@ project_info <- function(zoltar_connection, project_url) {
 #' Get information about a project's truth
 #'
 #' @return A `list` of project truth information for the passed project_url
-#' @param zoltar_connection A `ZoltarConnection` object as returned by \code{\link{new_connection}}
+#' @param zoltar_connection A `ZoltarConnection` object as returned by [new_connection()]
 #' @param project_url URL of a project in zoltar_connection's projects
 #' @export
 #' @examples \dontrun{
@@ -375,7 +375,7 @@ truth_info <- function(zoltar_connection, project_url) {
 #' Get information about a target
 #'
 #' @return A `list` of target information for the passed target_url
-#' @param zoltar_connection A `ZoltarConnection` object as returned by \code{\link{new_connection}}
+#' @param zoltar_connection A `ZoltarConnection` object as returned by [new_connection()]
 #' @param target_url URL of a target in zoltar_connection's targets
 #' @export
 #' @examples \dontrun{
@@ -389,7 +389,7 @@ target_info <- function(zoltar_connection, target_url) {
 #' Get information about a timezero
 #'
 #' @return A `list` of timezero information for the passed timezero_url
-#' @param zoltar_connection A `ZoltarConnection` object as returned by \code{\link{new_connection}}
+#' @param zoltar_connection A `ZoltarConnection` object as returned by [new_connection()]
 #' @param timezero_url URL of a timezero in zoltar_connection's timezeros
 #' @export
 #' @examples \dontrun{
@@ -403,7 +403,7 @@ timezero_info <- function(zoltar_connection, timezero_url) {
 #' Get information about a unit
 #'
 #' @return A `list` of unit information for the passed unit_url
-#' @param zoltar_connection A `ZoltarConnection` object as returned by \code{\link{new_connection}}
+#' @param zoltar_connection A `ZoltarConnection` object as returned by [new_connection()]
 #' @param unit_url URL of a unit in zoltar_connection's zoltar_units
 #' @export
 #' @examples \dontrun{

--- a/R/quantile.R
+++ b/R/quantile.R
@@ -1,6 +1,6 @@
 #' Converts forecast data from Zoltar's native `list` format to a quantile `data.frame`
 #'
-#' @return A `data.frame` from forecast_data that's the same as `data_frame_from_forecast_data` does except
+#' @return A `data.frame` from forecast_data that's the same as [data_frame_from_forecast_data()] does except
 #'   only includes point and quantile rows, and with this header: 'location', 'target', 'type', 'quantile',
 #'   'value', i.e., 'unit' -> 'location' and 'class' -> 'type'
 #' @param forecast_data Forecast data as a `list` in the Zoltar standard format

--- a/R/utils-pipe.R
+++ b/R/utils-pipe.R
@@ -1,6 +1,6 @@
 #' Pipe operator
 #'
-#' See \code{magrittr::\link[magrittr]{\%>\%}} for details.
+#' See `magrittr::[\%>\%][magrittr::\%>\%]` for details.
 #'
 #' @name %>%
 #' @rdname pipe

--- a/man/busy_poll_job.Rd
+++ b/man/busy_poll_job.Rd
@@ -7,7 +7,7 @@
 busy_poll_job(zoltar_connection, job_url, verbose = TRUE)
 }
 \arguments{
-\item{zoltar_connection}{A `ZoltarConnection` object as returned by \code{\link{new_connection}}}
+\item{zoltar_connection}{A \code{ZoltarConnection} object as returned by \code{\link[=new_connection]{new_connection()}}}
 
 \item{job_url}{URL of a valid job in zoltar_connection}
 

--- a/man/create_model.Rd
+++ b/man/create_model.Rd
@@ -7,12 +7,12 @@
 create_model(zoltar_connection, project_url, model_config)
 }
 \arguments{
-\item{zoltar_connection}{A `ZoltarConnection` object as returned by \code{\link{new_connection}}}
+\item{zoltar_connection}{A \code{ZoltarConnection} object as returned by \code{\link[=new_connection]{new_connection()}}}
 
 \item{project_url}{url of a project in zoltar_connection's projects. this is the project the new model will be created
 in}
 
-\item{model_config}{A `list` containing a Zoltar model configuration. An example: example-model-config.json .
+\item{model_config}{A \code{list} containing a Zoltar model configuration. An example: example-model-config.json .
 Full documentation at \url{https://docs.zoltardata.com/}.}
 }
 \value{

--- a/man/create_project.Rd
+++ b/man/create_project.Rd
@@ -7,9 +7,9 @@
 create_project(zoltar_connection, project_config)
 }
 \arguments{
-\item{zoltar_connection}{A `ZoltarConnection` object as returned by \code{\link{new_connection}}}
+\item{zoltar_connection}{A \code{ZoltarConnection} object as returned by \code{\link[=new_connection]{new_connection()}}}
 
-\item{project_config}{A `list` containing a Zoltar project configuration. note that this list validated by the
+\item{project_config}{A \code{list} containing a Zoltar project configuration. note that this list validated by the
 server and not here. An example: cdc-project.json Full documentation at \url{https://docs.zoltardata.com/}.}
 }
 \value{
@@ -17,7 +17,7 @@ project_url of the newly-created project
 }
 \description{
 Creates the project using the passed project configuration list. Fails if a project with the passed name already
-  exists.
+exists.
 }
 \examples{
 \dontrun{

--- a/man/data_frame_from_forecast_data.Rd
+++ b/man/data_frame_from_forecast_data.Rd
@@ -2,23 +2,23 @@
 % Please edit documentation in R/csv.R
 \name{data_frame_from_forecast_data}
 \alias{data_frame_from_forecast_data}
-\title{Converts forecast data from Zoltar's native `list` format to a `data.frame`}
+\title{Converts forecast data from Zoltar's native \code{list} format to a \code{data.frame}}
 \usage{
 data_frame_from_forecast_data(forecast_data)
 }
 \arguments{
-\item{forecast_data}{Forecast data as a `list` in the Zoltar standard format}
+\item{forecast_data}{Forecast data as a \code{list} in the Zoltar standard format}
 }
 \value{
-A `data.frame` from forecast_data in zoltar-specific format. The columns are:
-  'unit', 'target', 'class', 'value', 'cat', 'prob', 'sample', 'quantile', 'family',
-  'param1', 'param2', 'param3'. They are documented at
-  https://docs.zoltardata.com/fileformats/#forecast-data-format-csv .
-  NB: columns are all character (i.e., data type information from forecast_data is lost). Also note that a retracted
-  prediction element is represented as a single row with NA values for all but the first four columns.
+A \code{data.frame} from forecast_data in zoltar-specific format. The columns are:
+'unit', 'target', 'class', 'value', 'cat', 'prob', 'sample', 'quantile', 'family',
+'param1', 'param2', 'param3'. They are documented at
+https://docs.zoltardata.com/fileformats/#forecast-data-format-csv .
+NB: columns are all character (i.e., data type information from forecast_data is lost). Also note that a retracted
+prediction element is represented as a single row with NA values for all but the first four columns.
 }
 \description{
-Converts forecast data from Zoltar's native `list` format to a `data.frame`
+Converts forecast data from Zoltar's native \code{list} format to a \code{data.frame}
 }
 \examples{
 \dontrun{

--- a/man/delete_forecast.Rd
+++ b/man/delete_forecast.Rd
@@ -7,7 +7,7 @@
 delete_forecast(zoltar_connection, forecast_url)
 }
 \arguments{
-\item{zoltar_connection}{A `ZoltarConnection` object as returned by \code{\link{new_connection}}}
+\item{zoltar_connection}{A \code{ZoltarConnection} object as returned by \code{\link[=new_connection]{new_connection()}}}
 
 \item{forecast_url}{URL of a forecast in zoltar_connection's forecasts}
 }

--- a/man/delete_model.Rd
+++ b/man/delete_model.Rd
@@ -7,7 +7,7 @@
 delete_model(zoltar_connection, model_url)
 }
 \arguments{
-\item{zoltar_connection}{A `ZoltarConnection` object as returned by \code{\link{new_connection}}}
+\item{zoltar_connection}{A \code{ZoltarConnection} object as returned by \code{\link[=new_connection]{new_connection()}}}
 
 \item{model_url}{URL of a model in zoltar_connection's models}
 }

--- a/man/delete_project.Rd
+++ b/man/delete_project.Rd
@@ -7,7 +7,7 @@
 delete_project(zoltar_connection, project_url)
 }
 \arguments{
-\item{zoltar_connection}{A `ZoltarConnection` object as returned by \code{\link{new_connection}}}
+\item{zoltar_connection}{A \code{ZoltarConnection} object as returned by \code{\link[=new_connection]{new_connection()}}}
 
 \item{project_url}{URL of a project in zoltar_connection's projects}
 }

--- a/man/do_zoltar_query.Rd
+++ b/man/do_zoltar_query.Rd
@@ -18,7 +18,7 @@ do_zoltar_query(
 )
 }
 \arguments{
-\item{zoltar_connection}{A `ZoltarConnection` object as returned by \code{\link{new_connection}}}
+\item{zoltar_connection}{A \code{ZoltarConnection} object as returned by \code{\link[=new_connection]{new_connection()}}}
 
 \item{project_url}{URL of a project in zoltar_connection's projects}
 
@@ -35,14 +35,14 @@ Used for all query_types.}
 
 \item{types}{Character vector of prediction types to retrieve. Used for query_type = "forecasts".}
 
-\item{as_of}{a datetime used for query_type = "forecasts" that constrains based on forecast `issued_at`.
+\item{as_of}{a datetime used for query_type = "forecasts" that constrains based on forecast \code{issued_at}.
 must be a datetime as parsed by the dateutil python library
 https://dateutil.readthedocs.io/en/stable/index.html , which accepts a variety of styles.}
 
 \item{verbose}{if TRUE, print messages on job status poll}
 }
 \value{
-A `data.frame` of Job's data. Full documentation at \url{https://docs.zoltardata.com/}.
+A \code{data.frame} of Job's data. Full documentation at \url{https://docs.zoltardata.com/}.
 }
 \description{
 A convenience function to construct and execute a Zoltar query for either forecast or truth data.

--- a/man/download_forecast.Rd
+++ b/man/download_forecast.Rd
@@ -7,13 +7,13 @@
 download_forecast(zoltar_connection, forecast_url)
 }
 \arguments{
-\item{zoltar_connection}{A `ZoltarConnection` object as returned by \code{\link{new_connection}}}
+\item{zoltar_connection}{A \code{ZoltarConnection} object as returned by \code{\link[=new_connection]{new_connection()}}}
 
 \item{forecast_url}{URL of a forecast in zoltar_connection's forecasts}
 }
 \value{
-Forecast data as a `list` in the Zoltar standard format. meta information is ignored. Full documentation at
-  \url{https://docs.zoltardata.com/}.
+Forecast data as a \code{list} in the Zoltar standard format. meta information is ignored. Full documentation at
+\url{https://docs.zoltardata.com/}.
 }
 \description{
 Gets a forecast's data

--- a/man/edit_model.Rd
+++ b/man/edit_model.Rd
@@ -7,12 +7,12 @@
 edit_model(zoltar_connection, model_url, model_config)
 }
 \arguments{
-\item{zoltar_connection}{A `ZoltarConnection` object as returned by \code{\link{new_connection}}}
+\item{zoltar_connection}{A \code{ZoltarConnection} object as returned by \code{\link[=new_connection]{new_connection()}}}
 
 \item{model_url}{url of a project in zoltar_connection's projects. this is the project the new model will be editd
 in}
 
-\item{model_config}{A `list` containing a Zoltar model configuration. An example: example-model-config.json .
+\item{model_config}{A \code{list} containing a Zoltar model configuration. An example: example-model-config.json .
 Full documentation at \url{https://docs.zoltardata.com/}.}
 }
 \description{

--- a/man/edit_model.Rd
+++ b/man/edit_model.Rd
@@ -9,7 +9,7 @@ edit_model(zoltar_connection, model_url, model_config)
 \arguments{
 \item{zoltar_connection}{A \code{ZoltarConnection} object as returned by \code{\link[=new_connection]{new_connection()}}}
 
-\item{model_url}{url of a project in zoltar_connection's projects. this is the project the new model will be editd
+\item{model_url}{url of a project in zoltar_connection's projects. this is the project the new model will be edited
 in}
 
 \item{model_config}{A \code{list} containing a Zoltar model configuration. An example: example-model-config.json .

--- a/man/forecast_data_from_cdc_csv_file.Rd
+++ b/man/forecast_data_from_cdc_csv_file.Rd
@@ -8,7 +8,7 @@ forecast_data_from_cdc_csv_file(season_start_year, cdc_csv_file)
 }
 \arguments{
 \item{season_start_year}{An integer specifying the "season" that cdc_csv_file is in. Used to convert EWs to
-YYYY_MM_DD_DATE_FORMAT. zoltr uses week 30 as the season breakpoint, e.g. the "2016/2017 season" starts with}
+YYYY_MM_DD_DATE_FORMAT. \pkg{zoltr} uses week 30 as the season breakpoint, e.g. the "2016/2017 season" starts with}
 
 \item{cdc_csv_file}{A CDC CSV file}
 }

--- a/man/forecast_data_from_cdc_csv_file.Rd
+++ b/man/forecast_data_from_cdc_csv_file.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/cdc.R
 \name{forecast_data_from_cdc_csv_file}
 \alias{forecast_data_from_cdc_csv_file}
-\title{Loads and converts a CDC CSV file to Zoltar's native `list` format}
+\title{Loads and converts a CDC CSV file to Zoltar's native \code{list} format}
 \usage{
 forecast_data_from_cdc_csv_file(season_start_year, cdc_csv_file)
 }
@@ -13,10 +13,10 @@ YYYY_MM_DD_DATE_FORMAT. zoltr uses week 30 as the season breakpoint, e.g. the "2
 \item{cdc_csv_file}{A CDC CSV file}
 }
 \value{
-cdc_csv_file's data as Zoltar's native `list` format, but only the "predictions" item, and not "meta"
+cdc_csv_file's data as Zoltar's native \code{list} format, but only the "predictions" item, and not "meta"
 }
 \description{
-Loads and converts a CDC CSV file to Zoltar's native `list` format
+Loads and converts a CDC CSV file to Zoltar's native \code{list} format
 }
 \examples{
 \dontrun{

--- a/man/forecast_data_from_cdc_data_frame.Rd
+++ b/man/forecast_data_from_cdc_data_frame.Rd
@@ -2,18 +2,18 @@
 % Please edit documentation in R/cdc.R
 \name{forecast_data_from_cdc_data_frame}
 \alias{forecast_data_from_cdc_data_frame}
-\title{`forecast_data_from_cdc_csv_file()`helper}
+\title{\code{forecast_data_from_cdc_csv_file()}helper}
 \usage{
 forecast_data_from_cdc_data_frame(season_start_year, cdc_data_frame)
 }
 \arguments{
-\item{season_start_year}{as passed to `forecast_data_from_cdc_csv_file()`}
+\item{season_start_year}{as passed to \code{forecast_data_from_cdc_csv_file()}}
 
 \item{cdc_data_frame}{""}
 }
 \value{
-same as `forecast_data_from_cdc_csv_file()`
+same as \code{forecast_data_from_cdc_csv_file()}
 }
 \description{
-`forecast_data_from_cdc_csv_file()`helper
+\code{forecast_data_from_cdc_csv_file()}helper
 }

--- a/man/forecast_data_from_cdc_data_frame.Rd
+++ b/man/forecast_data_from_cdc_data_frame.Rd
@@ -2,18 +2,18 @@
 % Please edit documentation in R/cdc.R
 \name{forecast_data_from_cdc_data_frame}
 \alias{forecast_data_from_cdc_data_frame}
-\title{\code{forecast_data_from_cdc_csv_file()}helper}
+\title{\code{\link[=forecast_data_from_cdc_csv_file]{forecast_data_from_cdc_csv_file()}} helper}
 \usage{
 forecast_data_from_cdc_data_frame(season_start_year, cdc_data_frame)
 }
 \arguments{
-\item{season_start_year}{as passed to \code{forecast_data_from_cdc_csv_file()}}
+\item{season_start_year}{as passed to \code{\link[=forecast_data_from_cdc_csv_file]{forecast_data_from_cdc_csv_file()}}}
 
 \item{cdc_data_frame}{""}
 }
 \value{
-same as \code{forecast_data_from_cdc_csv_file()}
+same as [forecast_data_from_cdc_csv_file()}
 }
 \description{
-\code{forecast_data_from_cdc_csv_file()}helper
+\code{\link[=forecast_data_from_cdc_csv_file]{forecast_data_from_cdc_csv_file()}} helper
 }

--- a/man/forecast_info.Rd
+++ b/man/forecast_info.Rd
@@ -7,12 +7,12 @@
 forecast_info(zoltar_connection, forecast_url)
 }
 \arguments{
-\item{zoltar_connection}{A `ZoltarConnection` object as returned by \code{\link{new_connection}}}
+\item{zoltar_connection}{A \code{ZoltarConnection} object as returned by \code{\link[=new_connection]{new_connection()}}}
 
 \item{forecast_url}{URL of a forecast in zoltar_connection's forecasts}
 }
 \value{
-A `list` of forecast information for the passed forecast_url
+A \code{list} of forecast information for the passed forecast_url
 }
 \description{
 Gets a forecast's information

--- a/man/forecasts.Rd
+++ b/man/forecasts.Rd
@@ -7,12 +7,12 @@
 forecasts(zoltar_connection, model_url)
 }
 \arguments{
-\item{zoltar_connection}{A `ZoltarConnection` object as returned by \code{\link{new_connection}}}
+\item{zoltar_connection}{A \code{ZoltarConnection} object as returned by \code{\link[=new_connection]{new_connection()}}}
 
 \item{model_url}{URL of a model in zoltar_connection's models}
 }
 \value{
-A `data.frame` of forecast information for the passed model
+A \code{data.frame} of forecast information for the passed model
 }
 \description{
 Get a model's forecasts

--- a/man/get_resource.Rd
+++ b/man/get_resource.Rd
@@ -7,14 +7,14 @@
 get_resource(zoltar_connection, url, col_types = NULL)
 }
 \arguments{
-\item{zoltar_connection}{A `ZoltarConnection` object as returned by \code{\link{new_connection}}}
+\item{zoltar_connection}{A \code{ZoltarConnection} object as returned by \code{\link[=new_connection]{new_connection()}}}
 
 \item{url}{A string of the resource's URL}
 
 \item{col_types}{Same as readr::read_csv takes}
 }
 \value{
-A `list` that contiains JSON information for the passed URL
+A \code{list} that contiains JSON information for the passed URL
 }
 \description{
 Get JSON for a resource (URL). Authenticates if necessary

--- a/man/get_resource.Rd
+++ b/man/get_resource.Rd
@@ -14,7 +14,7 @@ get_resource(zoltar_connection, url, col_types = NULL)
 \item{col_types}{Same as readr::read_csv takes}
 }
 \value{
-A \code{list} that contiains JSON information for the passed URL
+A \code{list} that contains JSON information for the passed URL
 }
 \description{
 Get JSON for a resource (URL). Authenticates if necessary

--- a/man/job_data.Rd
+++ b/man/job_data.Rd
@@ -7,23 +7,23 @@
 job_data(zoltar_connection, job_url, query_type)
 }
 \arguments{
-\item{zoltar_connection}{A `ZoltarConnection` object as returned by \code{\link{new_connection}}}
+\item{zoltar_connection}{A \code{ZoltarConnection} object as returned by \code{\link[=new_connection]{new_connection()}}}
 
 \item{job_url}{URL of a valid job in zoltar_connection that has a data file associated with it}
 
 \item{query_type}{A character indicating the type of query to run. Must be one of: "forecasts" or "truth".}
 }
 \value{
-A `data.frame` of Job's data. The columns depend on query_type - see
-  \url{https://docs.zoltardata.com/fileformats/#truth-data-format-csv} and
-  \url{https://docs.zoltardata.com/fileformats/#forecast-data-format-csv}.
+A \code{data.frame} of Job's data. The columns depend on query_type - see
+\url{https://docs.zoltardata.com/fileformats/#truth-data-format-csv} and
+\url{https://docs.zoltardata.com/fileformats/#forecast-data-format-csv}.
 }
 \description{
 Downloads the data for jobs that have an associated file, such as a query's results. Called on Jobs
-that are the results of a project forecast or truth queries via `submit_query()`. NB: It is a 404 Not Found
+that are the results of a project forecast or truth queries via \code{submit_query()}. NB: It is a 404 Not Found
 error if this is called on a Job that has no underlying S3 data file, which can happen b/c: 1) 24 hours has
 passed (the expiration time) or 2) the Job is not complete and therefore has not saved the data file. For
-the latter you may use `busy_poll_job()` to ensure the job is done.
+the latter you may use \code{busy_poll_job()} to ensure the job is done.
 }
 \examples{
 \dontrun{

--- a/man/job_data.Rd
+++ b/man/job_data.Rd
@@ -20,10 +20,10 @@ A \code{data.frame} of Job's data. The columns depend on query_type - see
 }
 \description{
 Downloads the data for jobs that have an associated file, such as a query's results. Called on Jobs
-that are the results of a project forecast or truth queries via \code{submit_query()}. NB: It is a 404 Not Found
+that are the results of a project forecast or truth queries via \code{\link[=submit_query]{submit_query()}}. NB: It is a 404 Not Found
 error if this is called on a Job that has no underlying S3 data file, which can happen b/c: 1) 24 hours has
 passed (the expiration time) or 2) the Job is not complete and therefore has not saved the data file. For
-the latter you may use \code{busy_poll_job()} to ensure the job is done.
+the latter you may use \code{\link[=busy_poll_job]{busy_poll_job()}} to ensure the job is done.
 }
 \examples{
 \dontrun{

--- a/man/job_info.Rd
+++ b/man/job_info.Rd
@@ -7,13 +7,13 @@
 job_info(zoltar_connection, job_url)
 }
 \arguments{
-\item{zoltar_connection}{A `ZoltarConnection` object as returned by \code{\link{new_connection}}}
+\item{zoltar_connection}{A \code{ZoltarConnection} object as returned by \code{\link[=new_connection]{new_connection()}}}
 
 \item{job_url}{URL of a valid job in zoltar_connection}
 }
 \value{
-A `list` of job information for the passed job_url. it has these names:
-  id, url, status, user, created_at, updated_at, failure_message, input_json, output_json
+A \code{list} of job information for the passed job_url. it has these names:
+id, url, status, user, created_at, updated_at, failure_message, input_json, output_json
 }
 \description{
 Gets a job's information that can be used to track the job's progress. Jobs represent long-running

--- a/man/job_info_forecast_url.Rd
+++ b/man/job_info_forecast_url.Rd
@@ -7,9 +7,9 @@
 job_info_forecast_url(zoltar_connection, the_job_info)
 }
 \arguments{
-\item{zoltar_connection}{A `ZoltarConnection` object as returned by \code{\link{new_connection}}}
+\item{zoltar_connection}{A \code{ZoltarConnection} object as returned by \code{\link[=new_connection]{new_connection()}}}
 
-\item{the_job_info}{a `list` object as returned by \code{\link{job_info}}}
+\item{the_job_info}{a \code{list} object as returned by \code{\link[=job_info]{job_info()}}}
 }
 \value{
 A URL of the new forecast

--- a/man/latest_forecasts.Rd
+++ b/man/latest_forecasts.Rd
@@ -7,14 +7,14 @@
 latest_forecasts(zoltar_connection, project_url)
 }
 \arguments{
-\item{zoltar_connection}{A `ZoltarConnection` object as returned by \code{\link{new_connection}}}
+\item{zoltar_connection}{A \code{ZoltarConnection} object as returned by \code{\link[=new_connection]{new_connection()}}}
 
 \item{project_url}{URL of a project in zoltar_connection's projects}
 }
 \value{
-A `data.frame` of all of the latest forecasts for the passed project. columns: forecast_id, source.
-  (Later we may generalize to allow passing specific columns to retrieve, such as 'forecast_model_id',
-  'time_zero_id', 'issued_at', 'created_at', 'source', and 'notes'.)
+A \code{data.frame} of all of the latest forecasts for the passed project. columns: forecast_id, source.
+(Later we may generalize to allow passing specific columns to retrieve, such as 'forecast_model_id',
+'time_zero_id', 'issued_at', 'created_at', 'source', and 'notes'.)
 }
 \description{
 Get a project's latest_forecasts

--- a/man/model_info.Rd
+++ b/man/model_info.Rd
@@ -7,12 +7,12 @@
 model_info(zoltar_connection, model_url)
 }
 \arguments{
-\item{zoltar_connection}{A `ZoltarConnection` object as returned by \code{\link{new_connection}}}
+\item{zoltar_connection}{A \code{ZoltarConnection} object as returned by \code{\link[=new_connection]{new_connection()}}}
 
 \item{model_url}{URL of a model in zoltar_connection's models}
 }
 \value{
-A `list` of model information for the passed model_url
+A \code{list} of model information for the passed model_url
 }
 \description{
 Get information about a model

--- a/man/models.Rd
+++ b/man/models.Rd
@@ -7,12 +7,12 @@
 models(zoltar_connection, project_url)
 }
 \arguments{
-\item{zoltar_connection}{A `ZoltarConnection` object as returned by \code{\link{new_connection}}}
+\item{zoltar_connection}{A \code{ZoltarConnection} object as returned by \code{\link[=new_connection]{new_connection()}}}
 
 \item{project_url}{URL of a project in zoltar_connection's projects}
 }
 \value{
-A `data.frame` of model contents for all models in the passed project
+A \code{data.frame} of model contents for all models in the passed project
 }
 \description{
 Get a project's models

--- a/man/new_connection.Rd
+++ b/man/new_connection.Rd
@@ -7,14 +7,14 @@
 new_connection(host = "https://zoltardata.com")
 }
 \arguments{
-\item{host}{The Zoltar site to connect to. Does *not* include a trailing slash ('/'). Defaults to \url{https://zoltardata.com}}
+\item{host}{The Zoltar site to connect to. Does \emph{not} include a trailing slash ('/'). Defaults to \url{https://zoltardata.com}}
 }
 \value{
-A `ZoltarConnection` object
+A \code{ZoltarConnection} object
 }
 \description{
 Returns a new connection object, which is the starting point for working with the Zoltar API. Once you have the
-connection you can call \code{\link{zoltar_authenticate}} on it, and then call \code{\link{projects}} to get a list
+connection you can call \code{\link[=zoltar_authenticate]{zoltar_authenticate()}} on it, and then call \code{\link[=projects]{projects()}} to get a list
 of Project objects to start working with.
 }
 \details{

--- a/man/pipe.Rd
+++ b/man/pipe.Rd
@@ -7,6 +7,6 @@
 lhs \%>\% rhs
 }
 \description{
-See \code{magrittr::\link[magrittr]{\%>\%}} for details.
+See \verb{magrittr::[\\\%>\\\%][magrittr::\\\%>\\\%]} for details.
 }
 \keyword{internal}

--- a/man/project_info.Rd
+++ b/man/project_info.Rd
@@ -7,12 +7,12 @@
 project_info(zoltar_connection, project_url)
 }
 \arguments{
-\item{zoltar_connection}{A `ZoltarConnection` object as returned by \code{\link{new_connection}}}
+\item{zoltar_connection}{A \code{ZoltarConnection} object as returned by \code{\link[=new_connection]{new_connection()}}}
 
 \item{project_url}{URL of a project in zoltar_connection's projects}
 }
 \value{
-A `list` of project information for the passed project_url
+A \code{list} of project information for the passed project_url
 }
 \description{
 Get information about a project

--- a/man/projects.Rd
+++ b/man/projects.Rd
@@ -7,10 +7,10 @@
 projects(zoltar_connection)
 }
 \arguments{
-\item{zoltar_connection}{A `ZoltarConnection` object as returned by \code{\link{new_connection}}}
+\item{zoltar_connection}{A \code{ZoltarConnection} object as returned by \code{\link[=new_connection]{new_connection()}}}
 }
 \value{
-A `data.frame` of all projects' contents
+A \code{data.frame} of all projects' contents
 }
 \description{
 Get information about all projects

--- a/man/quantile_data_frame_from_forecast_data.Rd
+++ b/man/quantile_data_frame_from_forecast_data.Rd
@@ -2,20 +2,20 @@
 % Please edit documentation in R/quantile.R
 \name{quantile_data_frame_from_forecast_data}
 \alias{quantile_data_frame_from_forecast_data}
-\title{Converts forecast data from Zoltar's native `list` format to a quantile `data.frame`}
+\title{Converts forecast data from Zoltar's native \code{list} format to a quantile \code{data.frame}}
 \usage{
 quantile_data_frame_from_forecast_data(forecast_data)
 }
 \arguments{
-\item{forecast_data}{Forecast data as a `list` in the Zoltar standard format}
+\item{forecast_data}{Forecast data as a \code{list} in the Zoltar standard format}
 }
 \value{
-A `data.frame` from forecast_data that's the same as `data_frame_from_forecast_data` does except
-  only includes point and quantile rows, and with this header: 'location', 'target', 'type', 'quantile',
-  'value', i.e., 'unit' -> 'location' and 'class' -> 'type'
+A \code{data.frame} from forecast_data that's the same as \code{data_frame_from_forecast_data} does except
+only includes point and quantile rows, and with this header: 'location', 'target', 'type', 'quantile',
+'value', i.e., 'unit' -> 'location' and 'class' -> 'type'
 }
 \description{
-Converts forecast data from Zoltar's native `list` format to a quantile `data.frame`
+Converts forecast data from Zoltar's native \code{list} format to a quantile \code{data.frame}
 }
 \examples{
 \dontrun{

--- a/man/quantile_data_frame_from_forecast_data.Rd
+++ b/man/quantile_data_frame_from_forecast_data.Rd
@@ -10,7 +10,7 @@ quantile_data_frame_from_forecast_data(forecast_data)
 \item{forecast_data}{Forecast data as a \code{list} in the Zoltar standard format}
 }
 \value{
-A \code{data.frame} from forecast_data that's the same as \code{data_frame_from_forecast_data} does except
+A \code{data.frame} from forecast_data that's the same as \code{\link[=data_frame_from_forecast_data]{data_frame_from_forecast_data()}} does except
 only includes point and quantile rows, and with this header: 'location', 'target', 'type', 'quantile',
 'value', i.e., 'unit' -> 'location' and 'class' -> 'type'
 }

--- a/man/submit_query.Rd
+++ b/man/submit_query.Rd
@@ -7,13 +7,13 @@
 submit_query(zoltar_connection, project_url, query_type, query)
 }
 \arguments{
-\item{zoltar_connection}{A `ZoltarConnection` object as returned by \code{\link{new_connection}}}
+\item{zoltar_connection}{A \code{ZoltarConnection} object as returned by \code{\link[=new_connection]{new_connection()}}}
 
 \item{project_url}{URL of a project in zoltar_connection's projects}
 
 \item{query_type}{A character indicating the type of query to run. Must be one of: "forecasts" or "truth".}
 
-\item{query}{A `list` of character `list`s that constrains the queried data. It is the analog of
+\item{query}{A \code{list} of character \code{list}s that constrains the queried data. It is the analog of
 the JSON object documented at \url{https://docs.zoltardata.com/}. The keys vary depending on query_type. References
 to models, units, targets, and timezeros are strings that name the objects, and not IDs.}
 }

--- a/man/target_info.Rd
+++ b/man/target_info.Rd
@@ -7,12 +7,12 @@
 target_info(zoltar_connection, target_url)
 }
 \arguments{
-\item{zoltar_connection}{A `ZoltarConnection` object as returned by \code{\link{new_connection}}}
+\item{zoltar_connection}{A \code{ZoltarConnection} object as returned by \code{\link[=new_connection]{new_connection()}}}
 
 \item{target_url}{URL of a target in zoltar_connection's targets}
 }
 \value{
-A `list` of target information for the passed target_url
+A \code{list} of target information for the passed target_url
 }
 \description{
 Get information about a target

--- a/man/targets.Rd
+++ b/man/targets.Rd
@@ -7,12 +7,12 @@
 targets(zoltar_connection, project_url)
 }
 \arguments{
-\item{zoltar_connection}{A `ZoltarConnection` object as returned by \code{\link{new_connection}}}
+\item{zoltar_connection}{A \code{ZoltarConnection} object as returned by \code{\link[=new_connection]{new_connection()}}}
 
 \item{project_url}{URL of a project in zoltar_connection's projects}
 }
 \value{
-A `data.frame` of target contents for the passed project
+A \code{data.frame} of target contents for the passed project
 }
 \description{
 Get a project's targets

--- a/man/timezero_info.Rd
+++ b/man/timezero_info.Rd
@@ -7,12 +7,12 @@
 timezero_info(zoltar_connection, timezero_url)
 }
 \arguments{
-\item{zoltar_connection}{A `ZoltarConnection` object as returned by \code{\link{new_connection}}}
+\item{zoltar_connection}{A \code{ZoltarConnection} object as returned by \code{\link[=new_connection]{new_connection()}}}
 
 \item{timezero_url}{URL of a timezero in zoltar_connection's timezeros}
 }
 \value{
-A `list` of timezero information for the passed timezero_url
+A \code{list} of timezero information for the passed timezero_url
 }
 \description{
 Get information about a timezero

--- a/man/timezeros.Rd
+++ b/man/timezeros.Rd
@@ -7,12 +7,12 @@
 timezeros(zoltar_connection, project_url)
 }
 \arguments{
-\item{zoltar_connection}{A `ZoltarConnection` object as returned by \code{\link{new_connection}}}
+\item{zoltar_connection}{A \code{ZoltarConnection} object as returned by \code{\link[=new_connection]{new_connection()}}}
 
 \item{project_url}{URL of a project in zoltar_connection's projects}
 }
 \value{
-A `data.frame` of timezero contents for the passed project
+A \code{data.frame} of timezero contents for the passed project
 }
 \description{
 Get a project's timezeros

--- a/man/truth_info.Rd
+++ b/man/truth_info.Rd
@@ -7,12 +7,12 @@
 truth_info(zoltar_connection, project_url)
 }
 \arguments{
-\item{zoltar_connection}{A `ZoltarConnection` object as returned by \code{\link{new_connection}}}
+\item{zoltar_connection}{A \code{ZoltarConnection} object as returned by \code{\link[=new_connection]{new_connection()}}}
 
 \item{project_url}{URL of a project in zoltar_connection's projects}
 }
 \value{
-A `list` of project truth information for the passed project_url
+A \code{list} of project truth information for the passed project_url
 }
 \description{
 Get information about a project's truth

--- a/man/unit_info.Rd
+++ b/man/unit_info.Rd
@@ -7,12 +7,12 @@
 unit_info(zoltar_connection, unit_url)
 }
 \arguments{
-\item{zoltar_connection}{A `ZoltarConnection` object as returned by \code{\link{new_connection}}}
+\item{zoltar_connection}{A \code{ZoltarConnection} object as returned by \code{\link[=new_connection]{new_connection()}}}
 
 \item{unit_url}{URL of a unit in zoltar_connection's zoltar_units}
 }
 \value{
-A `list` of unit information for the passed unit_url
+A \code{list} of unit information for the passed unit_url
 }
 \description{
 Get information about a unit

--- a/man/upload_forecast.Rd
+++ b/man/upload_forecast.Rd
@@ -13,13 +13,13 @@ upload_forecast(
 )
 }
 \arguments{
-\item{zoltar_connection}{A `ZoltarConnection` object as returned by \code{\link{new_connection}}}
+\item{zoltar_connection}{A \code{ZoltarConnection} object as returned by \code{\link[=new_connection]{new_connection()}}}
 
 \item{model_url}{URL of a model in zoltar_connection's projects}
 
 \item{timezero_date}{The date of the project timezero you are uploading for. it is a string in format YYYYMMDD}
 
-\item{forecast_data}{Forecast data as a `list` in the Zoltar standard format}
+\item{forecast_data}{Forecast data as a \code{list} in the Zoltar standard format}
 
 \item{notes}{Optional user notes for the new forecast}
 }
@@ -28,7 +28,7 @@ A Job URL for the upload
 }
 \description{
 This function submits forecast data to the server for uploading. Returns a Job object that can be used to
-up, which depends on the number of current uploads in the queue. Zoltar tracks these via `Job` objects.)
+up, which depends on the number of current uploads in the queue. Zoltar tracks these via \code{Job} objects.)
 }
 \examples{
 \dontrun{

--- a/man/zoltar_authenticate.Rd
+++ b/man/zoltar_authenticate.Rd
@@ -18,7 +18,7 @@ None
 }
 \description{
 Returns a new \code{ZoltarConnection} object, which is the starting point for working with the Zoltar API.
-Once you have the connection you can call zoltar_authenticate() on it, and call projects() to get a list of objects
+Once you have the connection you can call \code{\link[=zoltar_authenticate]{zoltar_authenticate()}} on it, and call \code{\link[=projects]{projects()}} to get a list of objects
 to start working with.
 }
 \examples{

--- a/man/zoltar_authenticate.Rd
+++ b/man/zoltar_authenticate.Rd
@@ -7,7 +7,7 @@
 zoltar_authenticate(zoltar_connection, username, password)
 }
 \arguments{
-\item{zoltar_connection}{A `ZoltarConnection` object as returned by \code{\link{new_connection}}.}
+\item{zoltar_connection}{A \code{ZoltarConnection} object as returned by \code{\link[=new_connection]{new_connection()}}.}
 
 \item{username}{Username for the account to use on the connection's host}
 
@@ -17,7 +17,7 @@ zoltar_authenticate(zoltar_connection, username, password)
 None
 }
 \description{
-Returns a new `ZoltarConnection` object, which is the starting point for working with the Zoltar API.
+Returns a new \code{ZoltarConnection} object, which is the starting point for working with the Zoltar API.
 Once you have the connection you can call zoltar_authenticate() on it, and call projects() to get a list of objects
 to start working with.
 }

--- a/man/zoltar_units.Rd
+++ b/man/zoltar_units.Rd
@@ -7,12 +7,12 @@
 zoltar_units(zoltar_connection, project_url)
 }
 \arguments{
-\item{zoltar_connection}{A `ZoltarConnection` object as returned by \code{\link{new_connection}}}
+\item{zoltar_connection}{A \code{ZoltarConnection} object as returned by \code{\link[=new_connection]{new_connection()}}}
 
 \item{project_url}{URL of a project in zoltar_connection's projects}
 }
 \value{
-A `data.frame` of unit contents for the passed project
+A \code{data.frame} of unit contents for the passed project
 }
 \description{
 Get a project's zoltar_units

--- a/man/zoltr-package.Rd
+++ b/man/zoltr-package.Rd
@@ -6,11 +6,7 @@
 \alias{zoltr-package}
 \title{zoltr: Interface to the 'Zoltar' Forecast Repository API}
 \description{
-'Zoltar' <https://www.zoltardata.com/> is a website that provides a repository of model forecast results
-    in a standardized format and a central location. It supports storing, retrieving, comparing, and analyzing time
-    series forecasts for prediction challenges of interest to the modeling community. This package provides functions
-    for working with the 'Zoltar' API, including connecting and authenticating, getting meta information (projects,
-    models, and forecasts, and truth), and uploading, downloading, and deleting forecast and truth data.
+'Zoltar' <https://www.zoltardata.com/> is a website that provides a repository of model forecast results in a standardized format and a central location. It supports storing, retrieving, comparing, and analyzing time series forecasts for prediction challenges of interest to the modeling community. This package provides functions for working with the 'Zoltar' API, including connecting and authenticating, getting meta information (projects, models, and forecasts, and truth), and uploading, downloading, and deleting forecast and truth data.
 }
 \seealso{
 Useful links:


### PR DESCRIPTION
Hi,

I was browsing the online docs and noticed markdown syntax didn't render correctly (e.g., https://reichlab.io/zoltr/reference/targets.html). I went ahead and enable markdown syntax for roxygen2 comments and then converted everything to the new syntax. Please let me know if anything else is necessary to be able to merge this into the main branch.