### PR TITLE
create new prediction_types for mean and median

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: zoltr
 Title: Interface to the 'Zoltar' Forecast Repository API
-Version: 1.0.0
+Version: 1.0.1
 Authors@R: c(
     person("Matthew", "Cornell", role = c("aut", "cre"), email = "cornell@umass.edu"),
     person("Nicholas", "Reich", role = c("aut", "cph"), email = "nick@schoolph.umass.edu"))
@@ -32,6 +32,6 @@ Imports:
     rlang,
     magrittr,
     lubridate
-RoxygenNote: 7.2.1
+RoxygenNote: 7.2.3
 VignetteBuilder: knitr
 Roxygen: list(markdown = TRUE)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+# zoltr 1.0.1
+- added support for [create new prediction_types for mean and median #367](https://github.com/reichlab/forecast-repository/issues/367)
+
 # zoltr 1.0.0
 - added support for [add capacity to specify the issued_at date for an uploaded truth data batch #50](https://github.com/reichlab/zoltr/issues/50) by adding optional `issued_at` argument to `upload_truth()`
 

--- a/R/cdc.R
+++ b/R/cdc.R
@@ -65,7 +65,7 @@ forecast_data_from_cdc_data_frame <- function(season_start_year, cdc_data_frame)
 
   predictions <- list()
   cdc_data_frame_grouped <- cdc_data_frame %>%
-    dplyr::group_by(.data$location, .data$target, .data$type) %>%
+    dplyr::group_by(location, target, type) %>%
     dplyr::group_data()
   for (group_idx in seq_len(nrow(cdc_data_frame_grouped))) {
     group_row <- cdc_data_frame_grouped[group_idx,]  # group_row$location,  group_row$target,  group_row$type

--- a/R/quantile.R
+++ b/R/quantile.R
@@ -12,7 +12,7 @@
 #' @importFrom rlang .data
 quantile_data_frame_from_forecast_data <- function(forecast_data) {
   data_frame_from_forecast_data(forecast_data) %>%
-    dplyr::select(.data$unit, .data$target, .data$class, .data$quantile, .data$value) %>%
-    dplyr::rename(location = .data$unit, type = class) %>%
-    dplyr::filter(.data$type == "point" | .data$type == "quantile")
+    dplyr::select(unit, target, class, quantile, value) %>%
+    dplyr::rename(location = unit, type = class) %>%
+    dplyr::filter(type == "point" | type == "quantile")
 }

--- a/tests/testthat/data/docs-predictions-with-retractions-exp.csv
+++ b/tests/testthat/data/docs-predictions-with-retractions-exp.csv
@@ -1,5 +1,8 @@
 unit,target,class,value,cat,prob,sample,quantile,family,param1,param2,param3
 loc1,pct next week,point,NA,NA,NA,NA,NA,NA,NA,NA,NA
+loc1,pct next week,mean,NA,NA,NA,NA,NA,NA,NA,NA,NA
+loc1,pct next week,median,NA,NA,NA,NA,NA,NA,NA,NA,NA
+loc1,pct next week,mode,NA,NA,NA,NA,NA,NA,NA,NA,NA
 loc1,pct next week,named,NA,NA,NA,NA,NA,NA,NA,NA,NA
 loc2,pct next week,point,NA,NA,NA,NA,NA,NA,NA,NA,NA
 loc2,pct next week,bin,NA,NA,NA,NA,NA,NA,NA,NA,NA

--- a/tests/testthat/data/docs-predictions-with-retractions.json
+++ b/tests/testthat/data/docs-predictions-with-retractions.json
@@ -8,6 +8,21 @@
     },
     {"unit": "loc1",
       "target": "pct next week",
+      "class": "mean",
+      "prediction": null
+    },
+    {"unit": "loc1",
+      "target": "pct next week",
+      "class": "median",
+      "prediction": null
+    },
+    {"unit": "loc1",
+      "target": "pct next week",
+      "class": "mode",
+      "prediction": null
+    },
+    {"unit": "loc1",
+      "target": "pct next week",
       "class": "named",
       "prediction": null
     },

--- a/tests/testthat/data/docs-predictions.json
+++ b/tests/testthat/data/docs-predictions.json
@@ -176,6 +176,27 @@
         "value": 2.1
       }
     },
+    {"unit": "loc1",
+      "target": "pct next week",
+      "class": "mean",
+      "prediction": {
+        "value": 2.11
+      }
+    },
+    {"unit": "loc1",
+      "target": "pct next week",
+      "class": "median",
+      "prediction": {
+        "value": 2.12
+      }
+    },
+    {"unit": "loc1",
+      "target": "pct next week",
+      "class": "mode",
+      "prediction": {
+        "value": 2.13
+      }
+    },
     {
       "unit": "loc1",
       "target": "pct next week",

--- a/tests/testthat/test-forecast.R
+++ b/tests/testthat/test-forecast.R
@@ -84,7 +84,7 @@ test_that("download_forecast() returns JSON data as a list", {
     expect_equal(length(mock_calls(m)), 1)
     expect_equal(mock_args(m)[[1]][[2]], "http://example.com/api/forecast/1/data/")
 
-    expect_equal(length(act_data$predictions), 29)
+    expect_equal(length(act_data$predictions), 32)
 
     # spot-check a few "Season peak week" predictions (a date target)
     prediction_element <- act_data$predictions[[1]]
@@ -93,19 +93,19 @@ test_that("download_forecast() returns JSON data as a list", {
     expect_equal(prediction_element$class, "point")
     expect_equal(prediction_element$prediction$value, as.Date("2019-12-22", YYYY_MM_DD_DATE_FORMAT))
 
-    prediction_element <- act_data$predictions[[11]]
+    prediction_element <- act_data$predictions[[14]]
     expect_equal(prediction_element$unit, "loc2")
     expect_equal(prediction_element$target, "Season peak week")
     expect_equal(prediction_element$class, "bin")
     expect_equal(prediction_element$prediction$cat[[1]], as.Date("2019-12-15", YYYY_MM_DD_DATE_FORMAT))
 
-    prediction_element <- act_data$predictions[[12]]
+    prediction_element <- act_data$predictions[[15]]
     expect_equal(prediction_element$unit, "loc2")
     expect_equal(prediction_element$target, "Season peak week")
     expect_equal(prediction_element$class, "quantile")
     expect_equal(prediction_element$prediction$value[[1]], as.Date("2019-12-22", YYYY_MM_DD_DATE_FORMAT))
 
-    prediction_element <- act_data$predictions[[23]]
+    prediction_element <- act_data$predictions[[26]]
     expect_equal(prediction_element$unit, "loc3")
     expect_equal(prediction_element$target, "Season peak week")
     expect_equal(prediction_element$class, "sample")

--- a/vignettes/docs-predictions.json
+++ b/vignettes/docs-predictions.json
@@ -1,173 +1,6 @@
 {
-  "meta": {
-    "forecast": {
-      "id": 3,
-      "url": "http://127.0.0.1:8000/api/forecast/3/",
-      "forecast_model": "http://127.0.0.1:8000/api/model/5/",
-      "source": "docs-predictions.json",
-      "time_zero": {
-        "id": 5,
-        "url": "http://127.0.0.1:8000/api/timezero/5/",
-        "timezero_date": "2011-10-02",
-        "data_version_date": null,
-        "is_season_start": true,
-        "season_name": "2011-2012"
-      },
-      "created_at": "2020-03-05T15:47:47.369231-05:00",
-      "forecast_data": "http://127.0.0.1:8000/api/forecast/3/data/"
-    },
-    "units": [
-      {
-        "id": 23,
-        "url": "http://127.0.0.1:8000/api/unit/23/",
-        "abbreviation": "loc1",
-        "name": "location1"
-      },
-      {
-        "id": 24,
-        "url": "http://127.0.0.1:8000/api/unit/24/",
-        "abbreviation": "loc2",
-        "name": "location2"
-      },
-      {
-        "id": 25,
-        "url": "http://127.0.0.1:8000/api/unit/25/",
-        "abbreviation": "loc3",
-        "name": "location3"
-      }
-    ],
-    "targets": [
-      {
-        "id": 19,
-        "url": "http://127.0.0.1:8000/api/target/19/",
-        "name": "Season peak week",
-        "type": "date",
-        "description": "The week in which the peak y value is observed. Given dates represent the Sunday that begin the peak week. Externally to Zoltar, weeks will be calculated using standard definitions of MMWR weeks.",
-        "outcome_variable": "season peak week",
-        "is_step_ahead": false,
-        "cats": [
-          "2019-12-15",
-          "2019-12-22",
-          "2019-12-29",
-          "2020-01-05"
-        ]
-      },
-      {
-        "id": 18,
-        "url": "http://127.0.0.1:8000/api/target/18/",
-        "name": "above baseline",
-        "type": "binary",
-        "description": "Whether or not a region-specific threshold will be exceeded in a given season.",
-        "outcome_variable": "above baseline",
-        "is_step_ahead": false
-      },
-      {
-        "id": 16,
-        "url": "http://127.0.0.1:8000/api/target/16/",
-        "name": "cases next week",
-        "type": "discrete",
-        "description": "A forecasted integer number of cases for a future week.",
-        "outcome_variable": "cases",
-        "is_step_ahead": true,
-        "numeric_horizon": 1,
-        "reference_date_type": "MMWR_WEEK_LAST_TIMEZERO_MONDAY",
-        "range": [
-          0,
-          100000
-        ],
-        "cats": [
-          0,
-          2,
-          50
-        ]
-      },
-      {
-        "id": 15,
-        "url": "http://127.0.0.1:8000/api/target/15/",
-        "name": "pct next week",
-        "type": "continuous",
-        "description": "The forecasted percentage of positive tests for the next week",
-        "outcome_variable": "percentage positive tests",
-        "is_step_ahead": true,
-        "numeric_horizon": 1,
-        "reference_date_type": "MMWR_WEEK_LAST_TIMEZERO_MONDAY",
-        "range": [
-          0.0,
-          100.0
-        ],
-        "cats": [
-          0.0,
-          1.0,
-          1.1,
-          2.0,
-          2.2,
-          3.0,
-          3.3,
-          5.0,
-          10.0,
-          50.0
-        ]
-      },
-      {
-        "id": 17,
-        "url": "http://127.0.0.1:8000/api/target/17/",
-        "name": "season severity",
-        "type": "nominal",
-        "description": "The forecasted severity for a given season.",
-        "outcome_variable": "season severity",
-        "is_step_ahead": false,
-        "cats": [
-          "high",
-          "mild",
-          "moderate",
-          "severe"
-        ]
-      }
-    ]
-  },
+  "meta": {},
   "predictions": [
-    {
-      "unit": "loc1",
-      "target": "Season peak week",
-      "class": "point",
-      "prediction": {
-        "value": "2019-12-22"
-      }
-    },
-    {
-      "unit": "loc1",
-      "target": "Season peak week",
-      "class": "bin",
-      "prediction": {
-        "cat": ["2019-12-15", "2019-12-22", "2019-12-29"],
-        "prob": [0.01, 0.1, 0.89]
-      }
-    },
-    {
-      "unit": "loc1",
-      "target": "Season peak week",
-      "class": "sample",
-      "prediction": {
-        "sample": ["2020-01-05", "2019-12-15"]
-      }
-    },
-    {
-      "unit": "loc1",
-      "target": "above baseline",
-      "class": "point",
-      "prediction": {
-        "value": true
-      }
-    },
-    {
-      "unit": "loc1",
-      "target": "cases next week",
-      "class": "named",
-      "prediction": {
-        "family": "pois",
-        "param1": 1.1
-      }
-    },
     {
       "unit": "loc1",
       "target": "pct next week",
@@ -179,87 +12,35 @@
     {
       "unit": "loc1",
       "target": "pct next week",
+      "class": "mean",
+      "prediction": {
+        "value": 2.11
+      }
+    },
+    {
+      "unit": "loc1",
+      "target": "pct next week",
+      "class": "median",
+      "prediction": {
+        "value": 2.12
+      }
+    },
+    {
+      "unit": "loc1",
+      "target": "pct next week",
+      "class": "mode",
+      "prediction": {
+        "value": 2.13
+      }
+    },
+    {
+      "unit": "loc1",
+      "target": "pct next week",
       "class": "named",
       "prediction": {
         "family": "norm",
         "param1": 1.1,
         "param2": 2.2
-      }
-    },
-    {
-      "unit": "loc1",
-      "target": "season severity",
-      "class": "point",
-      "prediction": {
-        "value": "mild"
-      }
-    },
-    {
-      "unit": "loc1",
-      "target": "season severity",
-      "class": "bin",
-      "prediction": {
-        "cat": ["mild", "moderate", "severe"],
-        "prob": [0.0, 0.1, 0.9]
-      }
-    },
-    {
-      "unit": "loc2",
-      "target": "Season peak week",
-      "class": "point",
-      "prediction": {
-        "value": "2020-01-05"
-      }
-    },
-    {
-      "unit": "loc2",
-      "target": "Season peak week",
-      "class": "bin",
-      "prediction": {
-        "cat": ["2019-12-15", "2019-12-22", "2019-12-29", "2020-01-05"],
-        "prob": [0.01, 0.05, 0.05, 0.89]
-      }
-    },
-    {
-      "unit": "loc2",
-      "target": "Season peak week",
-      "class": "quantile",
-      "prediction": {
-        "quantile": [0.5, 0.75, 0.975],
-        "value": ["2019-12-22", "2019-12-29", "2020-01-05"]
-      }
-    },
-    {
-      "unit": "loc2",
-      "target": "above baseline",
-      "class": "bin",
-      "prediction": {
-        "cat": [true, false],
-        "prob": [0.9, 0.1]
-      }
-    },
-    {
-      "unit": "loc2",
-      "target": "above baseline",
-      "class": "sample",
-      "prediction": {
-        "sample": [true, false, true]
-      }
-    },
-    {
-      "unit": "loc2",
-      "target": "cases next week",
-      "class": "point",
-      "prediction": {
-        "value": 5
-      }
-    },
-    {
-      "unit": "loc2",
-      "target": "cases next week",
-      "class": "sample",
-      "prediction": {
-        "sample": [0, 2, 5]
       }
     },
     {
@@ -289,42 +70,44 @@
       }
     },
     {
-      "unit": "loc2",
-      "target": "season severity",
+      "unit": "loc3",
+      "target": "pct next week",
       "class": "point",
       "prediction": {
-        "value": "moderate"
+        "value": 3.567
+      }
+    },
+    {
+      "unit": "loc3",
+      "target": "pct next week",
+      "class": "sample",
+      "prediction": {
+        "sample": [2.3, 6.5, 0.0, 10.0234, 0.0001]
+      }
+    },
+    {
+      "unit": "loc1",
+      "target": "cases next week",
+      "class": "named",
+      "prediction": {
+        "family": "pois",
+        "param1": 1.1
       }
     },
     {
       "unit": "loc2",
-      "target": "season severity",
-      "class": "sample",
-      "prediction": {
-        "sample": ["moderate", "severe", "high", "moderate", "mild"]
-      }
-    },
-    {
-      "unit": "loc3",
-      "target": "Season peak week",
+      "target": "cases next week",
       "class": "point",
       "prediction": {
-        "value": "2019-12-29"
+        "value": 5
       }
     },
     {
-      "unit": "loc3",
-      "target": "Season peak week",
+      "unit": "loc2",
+      "target": "cases next week",
       "class": "sample",
       "prediction": {
-        "sample": ["2020-01-06", "2019-12-16"]}
-    },
-    {
-      "unit": "loc3",
-      "target": "above baseline",
-      "class": "sample",
-      "prediction": {
-        "sample": [false, true, true]
+        "sample": [0, 2, 5]
       }
     },
     {
@@ -354,19 +137,136 @@
       }
     },
     {
-      "unit": "loc3",
-      "target": "pct next week",
+      "unit": "loc1",
+      "target": "season severity",
       "class": "point",
       "prediction": {
-        "value": 3.567
+        "value": "mild"
+      }
+    },
+    {
+      "unit": "loc1",
+      "target": "season severity",
+      "class": "bin",
+      "prediction": {
+        "cat": ["mild", "moderate", "severe"],
+        "prob": [0.0, 0.1, 0.9]
+      }
+    },
+    {
+      "unit": "loc2",
+      "target": "season severity",
+      "class": "point",
+      "prediction": {
+        "value": "moderate"
+      }
+    },
+    {
+      "unit": "loc2",
+      "target": "season severity",
+      "class": "sample",
+      "prediction": {
+        "sample": ["moderate", "severe", "high", "moderate", "mild"]
+      }
+    },
+    {
+      "unit": "loc1",
+      "target": "above baseline",
+      "class": "point",
+      "prediction": {
+        "value": true
+      }
+    },
+    {
+      "unit": "loc2",
+      "target": "above baseline",
+      "class": "bin",
+      "prediction": {
+        "cat": [true, false],
+        "prob": [0.9, 0.1]
+      }
+    },
+    {
+      "unit": "loc2",
+      "target": "above baseline",
+      "class": "sample",
+      "prediction": {
+        "sample": [true, false, true]
       }
     },
     {
       "unit": "loc3",
-      "target": "pct next week",
+      "target": "above baseline",
       "class": "sample",
       "prediction": {
-        "sample": [2.3, 6.5, 0.0, 10.0234, 0.0001]
+        "sample": [false, true, true]
+      }
+    },
+    {
+      "unit": "loc1",
+      "target": "Season peak week",
+      "class": "point",
+      "prediction": {
+        "value": "2019-12-22"
+      }
+    },
+    {
+      "unit": "loc1",
+      "target": "Season peak week",
+      "class": "bin",
+      "prediction": {
+        "cat": ["2019-12-15", "2019-12-22", "2019-12-29"],
+        "prob": [0.01, 0.1, 0.89]
+      }
+    },
+    {
+      "unit": "loc1",
+      "target": "Season peak week",
+      "class": "sample",
+      "prediction": {
+        "sample": ["2020-01-05", "2019-12-15"]
+      }
+    },
+    {
+      "unit": "loc2",
+      "target": "Season peak week",
+      "class": "point",
+      "prediction": {
+        "value": "2020-01-05"
+      }
+    },
+    {
+      "unit": "loc2",
+      "target": "Season peak week",
+      "class": "bin",
+      "prediction": {
+        "cat": ["2019-12-15", "2019-12-22", "2019-12-29", "2020-01-05"],
+        "prob": [0.01, 0.05, 0.05, 0.89]
+      }
+    },
+    {
+      "unit": "loc2",
+      "target": "Season peak week",
+      "class": "quantile",
+      "prediction": {
+        "quantile": [0.5, 0.75, 0.975],
+        "value": ["2019-12-22", "2019-12-29", "2020-01-05"]
+      }
+    },
+    {
+      "unit": "loc3",
+      "target": "Season peak week",
+      "class": "point",
+      "prediction": {
+        "value": "2019-12-29"
+      }
+    },
+    {
+      "unit": "loc3",
+      "target": "Season peak week",
+      "class": "sample",
+      "prediction": {
+        "sample": ["2020-01-06", "2019-12-16"]
       }
     }
   ]

--- a/vignettes/getting-started.Rmd
+++ b/vignettes/getting-started.Rmd
@@ -34,7 +34,7 @@ Z_USERNAME=insert-your-username-here
 Z_PASSWORD=insert-your-password-here
 ```
 
-Note that the Zoltar service uses a "token"-based scheme for authentication. These tokens have a five minute expiration for security, which requires re-authentication after that period of time. The zoltr library takes care of re-authenticating as needed by passing your username and password back to the server to get another token. Note that the connection object returned by the `new_connection` function stores a token internally, so be careful if saving that object into a file.
+Note that the Zoltar service uses a "token"-based scheme for authentication. These tokens have a five-minute expiration for security, which requires re-authentication after that period of time. The zoltr library takes care of re-authenticating as needed by passing your username and password back to the server to get another token. Note that the connection object returned by the `new_connection` function stores a token internally, so be careful if saving that object into a file.
 
 
 ## Connect to the host and authenticate
@@ -97,7 +97,7 @@ There is other project-related information that you can access, such as its conf
 
 ## Query a project's forecast data
 
-You can query a project's forecast data using the `submit_query()` function. Keep in mind that Zoltar enqueues long operations like querying and uploading forecasts, which keeps the site responsive but makes the Zoltar API a little more complicated. Rather than having the `submit_query()` function _block_ until the query is done, you instead get a quick response in the form of a `Job` URL that you can pass to the `job_info()` function to check its status and find out if the upload is pending, successfully finished, or failed). (This is called _polling_ the host to ask the status.) Here we poll every second using the `busy_poll_job()` helper function. Then we use the `job_data()` function when the query is successfully completed to get the results as a `data.frame`.
+You can query a project's forecast data using the `submit_query()` function. Keep in mind that Zoltar enqueues long operations like querying and uploading forecasts, which keeps the site responsive but makes the Zoltar API a little more complicated. Rather than having the `submit_query()` function _block_ until the query is done, you instead get a quick response in the form of a `Job` URL that you can pass to the `job_info()` function to check its status and find out if the upload is pending, successfully finished, or failed. (This is called _polling_ the host to ask the status.) Here we poll every second using the `busy_poll_job()` helper function. Then we use the `job_data()` function when the query is successfully completed to get the results as a `data.frame`.
 
 > Note: You may find the `do_zoltar_query()` function helpful, which combines `submit_query()`, `busy_poll_job()`, and `job_data()` in one call.
 
@@ -113,7 +113,7 @@ the_job_data
 ```
 
 ```{r}
-forecast_data <- do_zoltar_query(zoltar_connection, project_url, "forecasts", "docs forecast model", 
+forecast_data <- do_zoltar_query(zoltar_connection, project_url, "forecasts", "docs_mod", 
                                  c("loc1", "loc2"), c("pct next week", "cases next week"),
                                  c("2011-10-02", "2011-10-09", "2011-10-16"), types = c("point", "quantile"))
 forecast_data

--- a/vignettes/project-owners.Rmd
+++ b/vignettes/project-owners.Rmd
@@ -24,7 +24,7 @@ knitr::opts_chunk$set(
 
 Welcome to the zoltr vignette for project owners and forecasters. You should read this if you are interested in creating and managing your own [zoltardata.com](https://www.zoltardata.com/) projects using this package to access them via the Zoltar API. Building on the _Getting Started_ vignette, this one covers creating projects and models, and uploading forecasts.
 
-Before starting you should have an account on [zoltardata.com](https://www.zoltardata.com/), and an [`.Renviron`](https://stat.ethz.ch/R-manual/R-devel/library/base/html/Startup.html) file set up as described in _Getting Started_.
+Before starting, you should have an account on [zoltardata.com](https://www.zoltardata.com/), and an [`.Renviron`](https://stat.ethz.ch/R-manual/R-devel/library/base/html/Startup.html) file set up as described in _Getting Started_.
 
 
 ## Connect to the host and authenticate
@@ -51,7 +51,7 @@ zoltar_authenticate(zoltar_connection, Sys.getenv("Z_USERNAME"), Sys.getenv("Z_P
 
 ## Create a sandbox project to play with
 
-Let's use the `create_project()` function to make a temporary project to work with. (Note that if you're repeating this step and need to delete a previously-created project, you can either use the web UI's delete button on the project detail page or call the zoltr `delete_project()` function to do it programmatically.) `create_project()` takes a `project_config` parameter that is a `list` specifying everything Zoltar needs to create a project, including meta information like name, whether it's public, etc. In addition it lists the units, targets, and timezeros to create. The new project's URL is returned, which you can pass to other functions. Here we use `docs-project.json`, which is the one that creates the example documentation project.
+Let's use the `create_project()` function to make a temporary project to work with. (Note that if you're repeating this step and need to delete a previously-created project, you can either use the web UI's delete button on the project detail page or call the zoltr `delete_project()` function to do it programmatically.) `create_project()` takes a `project_config` parameter that is a `list` specifying everything Zoltar needs to create a project, including meta information like name, whether it's public, etc. In addition, it lists the units, targets, and timezeros to create. The new project's URL is returned, which you can pass to other functions. Here we use `docs-project.json`, which is the one that creates the example documentation project.
 
 ```{r}
 project_config <- jsonlite::read_json("docs-project.json")  # "name": "My project"
@@ -108,7 +108,7 @@ str(the_forecasts)
 
 ## Clean up by deleting the sandbox project
 
-**NB: This will delete all of the data associated with the project without warning, including models and forecasts.** 
+**NB: This will delete all the data associated with the project without warning, including models and forecasts.** 
 
 ```{r}
 delete_project(zoltar_connection, project_url)


### PR DESCRIPTION
closes [create new prediction_types for mean and median #367] . removed ".data$" per package warning . NB: this is the first of two zoltr commits. this one contains all changes except generated outputs like pkgdown that require zoltar production being updated for the same issue #367.  I will create the second PR after zoltar is up.